### PR TITLE
Force parsing prices as double (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,29 @@ CHANGELOG
 * 🛠 Improvement changes
 * 🐞 Bug fixing
 
+## Upcoming version ##
+
+* 🐞 Integer prices were not parsed correctly ([#44](https://github.com/tankste/app/issues/44))
+
 ## 1.2.0 (2022-11-13) ##
 
-* 🐞 Refresh map by coming back to foreground (#5) 
-* 🐞 Wrong marker resolutions (#25)
+* 🐞 Refresh map by coming back to foreground ([#5](https://github.com/tankste/app/issues/5))
+* 🐞 Wrong marker resolutions ([#25](https://github.com/tankste/app/issues/25))
 * 🛠 Highlight searched gas price on page details
-* 🛠 Show progress & errors (#16)
-* ➕ Navigation app selection in settings (#27)
-* ➕ Developer settings (#30)
-* ➕ Apple Apps for iOS (#4)
-* ➕ Open Street Map for Android (#7)
+* 🛠 Show progress & errors ([#16](https://github.com/tankste/app/issues/16))
+* ➕ Navigation app selection in settings ([#27](https://github.com/tankste/app/issues/27))
+* ➕ Developer settings ([#30](https://github.com/tankste/app/issues/30))
+* ➕ Apple Apps for iOS ([#4](https://github.com/tankste/app/issues/4))
+* ➕ Open Street Map for Android ([#7](https://github.com/tankste/app/issues/7))
 
 ## 1.1.0 (2022-07-12) ##
 
 * ➕ Details station page
-  * ➕ Station address
-  * ➕ Open times
-  * ➕ All gas prices
-  * ➕ Route preview
-  * ➕ Open navigation app for routing 
+    * ➕ Station address
+    * ➕ Open times
+    * ➕ All gas prices
+    * ➕ Route preview
+    * ➕ Open navigation app for routing
 
 ## 1.0.0 (2022-07-07) ##
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -58,6 +58,10 @@ android {
         release {
             shrinkResources true
             minifyEnabled true
+
+            ndk {
+                debugSymbolLevel 'FULL'
+            }
         }
     }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -386,7 +386,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
     if (!station.isOpen || price == 0.0) {
       priceText = "-,--\u{207B}";
     } else {
-      priceText = price.toString().replaceAll('.', ',');
+      priceText = price.toStringAsFixed(3).replaceAll('.', ',');
     }
 
     if (priceText.length == 5) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:ui' as ui;
 import 'package:core/config/config_repository.dart';
 import 'package:core/cubit/base_state.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:geolocator/geolocator.dart';
@@ -97,7 +98,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   CameraPosition? _ownPosition;
   MapController? _mapController;
   bool _isLoading = true;
-  Exception? _error;
+  String? _errorDetails;
 
   @override
   Widget build(BuildContext context) {
@@ -126,7 +127,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
           _isLoading
               ? const SafeArea(child: LinearProgressIndicator())
               : Container(),
-          _error != null
+          _errorDetails != null
               ? Positioned(
                   top: 8,
                   left: 8,
@@ -158,7 +159,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
                                         builder: (context) {
                                           return AlertDialog(
                                             title: const Text('Fehler Details'),
-                                            content: Text(_error.toString()),
+                                            content: Text(_errorDetails ?? ""),
                                             actions: <Widget>[
                                               TextButton(
                                                   onPressed: () =>
@@ -475,7 +476,7 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   Future<List<StationModel>> _requestStations(CameraPosition location) async {
     setState(() {
       _isLoading = true;
-      _error = null;
+      _errorDetails = null;
     });
 
     GetStationsUseCase getStationsUseCase = GetStationsUseCaseImpl(
@@ -610,8 +611,18 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
               _markers = m;
             }))
         .catchError((error) {
+          if (kDebugMode) {
+            if (error is Error) {
+              print("===== Error =====");
+              print("$error\n${error.stackTrace}");
+            } else if (error is Exception) {
+              print("===== Error =====");
+              print(error.toString());
+            }
+          }
+
           setState(() {
-            _error = error;
+            _errorDetails = error.toString();
             _isLoading = false;
           });
         });

--- a/station/lib/details/station_details_page.dart
+++ b/station/lib/details/station_details_page.dart
@@ -241,7 +241,7 @@ class StationDetailsPage extends StatelessWidget {
     if (!isOpen || price == 0) {
       priceText = "-,--\u{207B}";
     } else {
-      priceText = price.toString().replaceAll('.', ',');
+      priceText = price.toStringAsFixed(3).replaceAll('.', ',');
     }
 
     if (priceText.length == 5) {

--- a/station/lib/station_model.dart
+++ b/station/lib/station_model.dart
@@ -26,11 +26,11 @@ class StationModel {
         parsedJson['place']?.trim() ?? "",
       ),
       StationPricesModel(
-        (priceType == "e5" ? parsedJson['price'] : parsedJson['e5']) ?? 0.0,
+        (priceType == "e5" ? _parseDouble(parsedJson['price']) : _parseDouble(parsedJson['e5'])) ?? 0.0,
         StationPriceRange.unknown,
-        (priceType == "e10" ? parsedJson['price'] : parsedJson['e10']) ?? 0.0,
+        (priceType == "e10" ? _parseDouble(parsedJson['price']) : _parseDouble(parsedJson['e10'])) ?? 0.0,
         StationPriceRange.unknown,
-        (priceType == "diesel" ? parsedJson['price'] : parsedJson['diesel']) ?? 0.0,
+        (priceType == "diesel" ? _parseDouble(parsedJson['price']) : _parseDouble(parsedJson['diesel'])) ?? 0.0,
         StationPriceRange.unknown,
       ),
       CoordinateModel(
@@ -40,6 +40,18 @@ class StationModel {
       _parseOpenTimes(parsedJson),
       parsedJson['isOpen'] ?? false,
     );
+  }
+
+  static double? _parseDouble(dynamic value) {
+    if (value is double) {
+      return value;
+    }
+
+    if (value is int) {
+      return value.toDouble();
+    }
+
+    return null;
   }
 
   static List<StationOpenTime> _parseOpenTimes(


### PR DESCRIPTION
Described in #44 integer number that will be also used for prices by Tankerkoenig are not parsed correctly and will cause to an error.

Changes: 
- Force parsing price integers to double.
- Display error dialog for type `Error` too.

Closes #44.