### PR TITLE
Fix parsing round integer coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ CHANGELOG
 
 ## Upcoming version ##
 
+## 1.2.2 (2022-12-13) ##
+
+* 🐞 Integer coordinates were not parsed correctly ([#47](https://github.com/tankste/app/issues/44))
+
+
 ## 1.2.1 (2022-11-21) ##
 
 * 🐞 Integer prices were not parsed correctly ([#44](https://github.com/tankste/app/issues/44))

--- a/station/lib/station_model.dart
+++ b/station/lib/station_model.dart
@@ -26,16 +26,25 @@ class StationModel {
         parsedJson['place']?.trim() ?? "",
       ),
       StationPricesModel(
-        (priceType == "e5" ? _parseDouble(parsedJson['price']) : _parseDouble(parsedJson['e5'])) ?? 0.0,
+        (priceType == "e5"
+                ? _parseDouble(parsedJson['price'])
+                : _parseDouble(parsedJson['e5'])) ??
+            0.0,
         StationPriceRange.unknown,
-        (priceType == "e10" ? _parseDouble(parsedJson['price']) : _parseDouble(parsedJson['e10'])) ?? 0.0,
+        (priceType == "e10"
+                ? _parseDouble(parsedJson['price'])
+                : _parseDouble(parsedJson['e10'])) ??
+            0.0,
         StationPriceRange.unknown,
-        (priceType == "diesel" ? _parseDouble(parsedJson['price']) : _parseDouble(parsedJson['diesel'])) ?? 0.0,
+        (priceType == "diesel"
+                ? _parseDouble(parsedJson['price'])
+                : _parseDouble(parsedJson['diesel'])) ??
+            0.0,
         StationPriceRange.unknown,
       ),
       CoordinateModel(
-        parsedJson['lat'] ?? "",
-        parsedJson['lng'] ?? "",
+        _parseDouble(parsedJson['lat']) ?? 0.0,
+        _parseDouble(parsedJson['lng']) ?? 0.0,
       ),
       _parseOpenTimes(parsedJson),
       parsedJson['isOpen'] ?? false,


### PR DESCRIPTION
Described in #47 integer number that will be also used for coordinates by Tankerkoenig are not parsed correctly and will cause to an error.

Changes:
* Force parsing coordinate integers to double.

Closes #47.