### PR TITLE
🧹 Add `nextGenerationMarkers` feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ CHANGELOG
 
 ## Upcoming version ##
 
+- 🧹 Add `nextGenerationMarkers` feature flag
+
 ## 2.2.1 (2026-03-02) ##
 
 - 🌟 Create review package with closed & floss variants

--- a/settings/lib/model/developer_settings_model.dart
+++ b/settings/lib/model/developer_settings_model.dart
@@ -30,4 +30,4 @@ class DeveloperSettingsModel {
   }
 }
 
-enum Feature { stationMetaInfo }
+enum Feature { nextGenerationMarkers, stationMetaInfo }

--- a/station/lib/di/station_module_factory.dart
+++ b/station/lib/di/station_module_factory.dart
@@ -1,3 +1,4 @@
+import 'package:settings/di/settings_module_factory.dart';
 import 'package:station/repository/config_repository.dart';
 import 'package:station/repository/currency_repository.dart';
 import 'package:station/repository/marker_repository.dart';
@@ -11,12 +12,17 @@ import 'package:core/di/core_module_factory.dart';
 class StationModuleFactory {
   static MarkerRepository createMarkerRepository() {
     return TanksteWebMarkerRepository(
-        createCurrencyRepository(), createConfigRepository());
+      createCurrencyRepository(),
+      createConfigRepository(),
+      SettingsModuleFactory.createDeveloperSettingsRepository(),
+    );
   }
 
   static StationRepository createStationRepository() {
     return TanksteWebStationRepository(
-        createCurrencyRepository(), createConfigRepository());
+      createCurrencyRepository(),
+      createConfigRepository(),
+    );
   }
 
   static PriceRepository createPriceRepository() {

--- a/station/lib/repository/marker_repository.dart
+++ b/station/lib/repository/marker_repository.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:core/log/log.dart';
 import 'package:multiple_result/multiple_result.dart';
 import 'package:navigation/navigation.dart';
+import 'package:settings/model/developer_settings_model.dart';
+import 'package:settings/repository/developer_settings_repository.dart';
 import 'package:station/model/config_model.dart';
 import 'package:station/model/currency_model.dart';
 import 'package:station/model/marker_model.dart';
@@ -22,11 +24,13 @@ class TanksteWebMarkerRepository extends MarkerRepository {
 
   late CurrencyRepository _currencyRepository;
   late ConfigRepository _configRepository;
+  late DeveloperSettingsRepository _developerSettingsRepository;
 
   factory TanksteWebMarkerRepository(CurrencyRepository currencyRepository,
-      ConfigRepository configRepository) {
+      ConfigRepository configRepository, DeveloperSettingsRepository developerSettingsRepository) {
     _instance._currencyRepository = currencyRepository;
     _instance._configRepository = configRepository;
+    _instance._developerSettingsRepository = developerSettingsRepository;
     return _instance;
   }
 
@@ -59,7 +63,13 @@ class TanksteWebMarkerRepository extends MarkerRepository {
           .map((c) => "boundary[]=${c.latitude},${c.longitude}")
           .join("&");
 
-      Uri url = Uri.parse('${config.apiBaseUrl}/markers?$boundQuery');
+      String nextGenerationQuery = "";
+      DeveloperSettingsModel developerSettings = await _developerSettingsRepository.get().first;
+      if (developerSettings.isFeatureEnabled(Feature.nextGenerationMarkers)) {
+        nextGenerationQuery = "&nextGeneration=true";
+      }
+
+      Uri url = Uri.parse('${config.apiBaseUrl}/markers?$boundQuery$nextGenerationQuery');
       http.Response response = await http
           .get(url); //TODO: add `, headers: await _apiRepository.getHeaders()`
       if (response.statusCode >= 200 && response.statusCode <= 299) {


### PR DESCRIPTION
Fixes #92.

Add flag an query to markers endpoint call that allow to test new markers logic in production.